### PR TITLE
Allow to create a class "A extends B"

### DIFF
--- a/src/Creator.ts
+++ b/src/Creator.ts
@@ -39,6 +39,13 @@ export default class Creator {
         }
 
         let filename = name.endsWith('.php') ? name : name + '.php'
+        
+        let space_index : int = filename.indexOf(' ');
+        if (space_index > 0) {
+            filename = filename.substring(0, space_index);
+        }
+
+        
         let fullFilename = folder.fsPath + path.sep + filename
 
         this.writeFile(type, name, fullFilename, namespace)


### PR DESCRIPTION
When you input "A extends B" as a class name, everything works well apart from the file now being named "A extends B.php". This pull request fixes that by cutting the filename off at the first space character.