### PR TITLE
Add new line before `strict_types`

### DIFF
--- a/src/Creator.ts
+++ b/src/Creator.ts
@@ -58,6 +58,7 @@ export default class Creator {
         let content = "<?php\n"
 
         if(vscode.workspace.getConfiguration("phpCreateClass").get("strict_types")) {
+            content += "\n"
             content += "declare(strict_types=1);\n"
         }
 


### PR DESCRIPTION
Current version does not add whitespace between PHP opening tag and the `declare()`. This PR does that.

Current release:
![Screenshot 2022-08-16 at 09 30 08](https://user-images.githubusercontent.com/6536260/184822832-eb97b27b-0b6f-48f0-889f-6aed98d3951c.png)
