### PR TITLE
Update Creator.ts

### DIFF
--- a/src/Creator.ts
+++ b/src/Creator.ts
@@ -54,7 +54,9 @@ export default class Creator {
             vscode.window.showErrorMessage(this.msgFileExists)
             return
         }
-
+    
+        name = name.replace(/\.php+$/g, "")
+        
         let content = "<?php\n"
 
         if(vscode.workspace.getConfiguration("phpCreateClass").get("strict_types")) {


### PR DESCRIPTION
Currently if you create a class with a` .php` extension in it. It will also be used as the class name when the file is being created.
This PR will automatically remove the `.php` extension to be used as the class name.