### PR TITLE
Add new configuration for set final class.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,13 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Set `strict_types` directive when creating a file"
+        },
+        "phpCreateClass.finalClass": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Set `final` modifier when creating a class"
         }
-      }
+      } 
     }
   },
   "devDependencies": {

--- a/src/Creator.ts
+++ b/src/Creator.ts
@@ -67,7 +67,17 @@ export default class Creator {
         content += "\n"
         content += "namespace " + namespace + ";\n"
         content += "\n"
-        content += type + " " + name + "\n"
+		
+		if(vscode.workspace.getConfiguration("phpCreateClass").get("finalClass") && type === "class") {
+
+            content += "final" + " " + type + " " + name + "\n";
+
+        }else{
+
+            content += type + " " + name + "\n";
+
+        }
+		
         content += "{\n\n}\n"
 
         fs.writeFileSync(filename, content)


### PR DESCRIPTION
The first one is that the classes can be configured to be "final" by default, because inheritance is often misused, and in design patterns it is usually recommended not to use it, in addition to the fact that when creating value objects they will always be finals. This is what I have been working on and I have made a "pull request", with the possible changes. 
